### PR TITLE
Remove Waffle Links from bottom of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,3 @@ For **PRODUCTION** replace the localhost and port (http://localhost:5000) with t
 1.  For a local dev you can enter any random string similar to a password. For production you can use a more secure random number/password generator.
 
 - cookieKey: 'Place cookieKey Here'
-
-### Waffle Link
-
-This repo was created from https://cfd-new.herokuapp.com. Use [the Waffle board](https://waffle.io/codefordenver/habitat-group-contacts) for this repo to always know what to do next for your project!


### PR DESCRIPTION
This PR (:warning: mostly) closes #79 

#### What does this PR do?
Removes broken links, but only from the bottom of the README. There are still broken links to Waffle in the purple image near the top (called `Stories Ready to Work On`), which I considered replacing with a link to this repo's Issues page, but looking at the picture there I wondered if Waffle was part of the app (i.e. managing tasks for habit-group-contacts) rather than an issue ticker for this repo (i.e to fix the app's code).

#### How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)
😕

![](put .gif link here - can be found under "advanced" on giphy)
